### PR TITLE
Fixing the import of Bower dependencies

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,8 +1,6 @@
 /* jshint node: true */
 /* global require, module */
 
-var mergeTrees = require('broccoli-merge-trees');
-var pickFiles = require('broccoli-static-compiler');
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 var app = new EmberAddon({
@@ -24,12 +22,4 @@ var app = new EmberAddon({
 // please specify an object with the list of modules as keys
 // along with the exports of each module as its value.
 
-var fontAwesome = pickFiles(app.bowerDirectory + '/font-awesome/fonts', {
-    srcDir: '/',
-    files: ['*'],
-    destDir: '/fonts'
-});
-
-app.import(app.bowerDirectory + '/font-awesome/css/font-awesome.css');
-
-module.exports = mergeTrees([app.toTree(), fontAwesome]);
+module.exports = app.toTree();

--- a/blueprints/ember-cli-notifications/index.js
+++ b/blueprints/ember-cli-notifications/index.js
@@ -1,0 +1,10 @@
+/* jshint node: true */
+'use strict';
+
+module.exports = {
+    normalizeEntityName: function() {},
+
+    afterInstall: function() {
+        return this.addBowerPackageToProject('font-awesome');
+    }
+};

--- a/index.js
+++ b/index.js
@@ -2,5 +2,25 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-cli-notifications'
+    name: 'ember-cli-notifications',
+    included: function(app) {
+        this._super.included(app);
+
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.eot', {
+            destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.svg', {
+            destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.ttf', {
+            destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff', {
+            destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff2', {
+            destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/css/font-awesome.css');
+    }
 };

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
-    "broccoli-merge-trees": "^0.2.1",
     "broccoli-sass": "0.3.3",
-    "broccoli-static-compiler": "^0.2.1",
     "ember-cli": "0.1.12",
     "ember-cli-6to5": "^3.0.0",
     "ember-cli-app-version": "0.3.1",


### PR DESCRIPTION
Bower dependencies should now be correctly included and used in the app following a `ember install:addon ember-cli-notifications`.
