### PR TITLE
Using a context-switching form of each is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Include this snippet in your Handlebars template to display the notifications.
 
 ```hbs
 <div class="notifications-container">
-    {{#each notifications}}
+    {{#each notification in notifications}}
         {{notification-message notification=this}}
     {{/each}}
 </div>


### PR DESCRIPTION
Getting rid of this warning:

> DEPRECATION: Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.
