### PR TITLE
added a clearAll helper to remove all active notifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ember install ember-cli-notifications
 
 From within your controller or route.
 
+Add a notification
 ```js
 actions: {
     saveOptions: function() {
@@ -25,6 +26,8 @@ actions: {
     }
 }
 ```
+
+Add a notification with autoClear
 ```js
 actions: {
     saveOptions: function() {
@@ -46,6 +49,21 @@ actions: {
 }
 ```
 
+Remove all active notifications using clearAll() before adding a new notification
+```js
+actions: {
+    saveOptions: function() {
+        this.get('model').save()
+        .then(function(){
+            this.notifications.clearAll();
+            this.notifications.addNotification({
+                message: 'Successfully saved your settings',
+                type: 'success'
+            });
+        }.bind(this))
+    }
+}
+```
 ### Template
 
 Include this snippet in your Handlebars template to display the notifications.

--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -46,5 +46,9 @@ export default Ember.ArrayProxy.extend({
                 this.removeNotification(notification);
             }
         }.bind(this), notification.clearDuration);
+    },
+
+    clearAll: function(){
+      this.set('content', Ember.A());
     }
 });

--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -48,7 +48,7 @@ export default Ember.ArrayProxy.extend({
         }.bind(this), notification.clearDuration);
     },
 
-    clearAll: function(){
-      this.set('content', Ember.A());
+    clearAll: function() {
+        this.set('content', Ember.A());
     }
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -26,6 +26,9 @@ export default Ember.Controller.extend({
                 message: "A warning notification",
                 type: 'warning'
             });
+        },
+        clearAll: function() {
+            this.notifications.clearAll();
         }
     }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -7,9 +7,13 @@
 <h2>ember-cli-notifications</h2>
 <p>Push a button below to trigger a notification</p>
 
+<h3>Notifications</h3>
 <button {{action 'showSuccess'}} title="Show a success notification">Success (auto clear)</button>
 <button {{action 'showInfo'}} title="Show an info notification">Info</button>
 <button {{action 'showError'}} title="Show an error notification">Error</button>
 <button {{action 'showWarning'}} title="Show a warning notification">Warning</button>
+
+<h3>Clear</h3>
+<button {{action 'clearAll'}} title="Clear all present notifications">Clear all</button>
 
 {{outlet}}


### PR DESCRIPTION
Adding clearAll() for notifications to remove all active notifications.

usage:

```
this.notifications.clearAll();
```

Addresses issue #29 
