### PR TITLE
Replace bind-attr with new handlebars attribute syntax

### DIFF
--- a/app/templates/components/notification-message.hbs
+++ b/app/templates/components/notification-message.hbs
@@ -1,6 +1,6 @@
 <div class="c-notification__icon">
   <span>
-    <i {{bind-attr class=":fa notificationIcon"}}></i>
+    <i class="fa {{notificationIcon}}"></i>
   </span>
 </div>
 <div class="c-notification__content">


### PR DESCRIPTION
This fixes deprecation warnings in ember >= 1.13.0
