### PR TITLE
Allow use of Bootstrap icons in place of Font Awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ From within your controller or route.
 
 ```js
 actions: {
-    saveOptions() {
-        this.notifications.addNotification({
-            message: 'Saved successfully!',
-            type: 'success'
-        });
-    }
+  saveOptions() {
+    this.notifications.addNotification({
+      message: 'Saved successfully!',
+      type: 'success'
+    });
+  }
 }
 ```
 
@@ -34,22 +34,22 @@ actions: {
 
 ```js
 actions: {
-    saveOptions() {
-        this.get('model').save()
-        .then(() => {
-            this.notifications.addNotification({
-                message: 'Successfully saved your settings',
-                type: 'success',
-                autoClear: true
-            });
-        }),
-        .catch((err) => {
-            this.notifications.addNotification({
-                message: 'Something went wrong'
-                type: 'error'
-            });
-        });
-    }
+  saveOptions() {
+    this.get('model').save()
+    .then(() => {
+      this.notifications.addNotification({
+        message: 'Successfully saved your settings',
+        type: 'success',
+        autoClear: true
+      });
+    }),
+    .catch((err) => {
+      this.notifications.addNotification({
+        message: 'Something went wrong'
+        type: 'error'
+      });
+    });
+  }
 }
 ```
 
@@ -57,40 +57,52 @@ actions: {
 
 ```js
 actions: {
-    saveOptions() {
-        this.get('model').save()
-        .then(() => {
-            this.notifications.clearAll();
-            this.notifications.addNotification({
-                message: 'Successfully saved your settings',
-                type: 'success'
-            });
-        })
-    }
+  saveOptions() {
+    this.get('model').save()
+    .then(() => {
+      this.notifications.clearAll();
+      this.notifications.addNotification({
+        message: 'Successfully saved your settings',
+        type: 'success'
+      });
+    })
+  }
 }
 ```
+
+### Set a global, default duration time
+
+This code only needs to be called in one place such as your application route.
+
+```js
+this.notifications.setDefaultClearNotification(1000);
+```
+
 ### Template
 
 Include this snippet in your Handlebars template to display the notifications.
 
 ```hbs
 <div class="c-notification__container">
-    {{#each notifications as |notification|}}
-        {{notification-message notification=notification}}
-    {{/each}}
+  {{#each notifications as |notification|}}
+    {{notification-message notification=notification}}
+  {{/each}}
 </div>
 ```
 
-## Font Awesome
+## Icons
 
-[Font Awesome] is required as part of the addon to display the message type icons on the notifications.
+By default, [Font Awesome] is used for the message type icons on the notifications. Alternatively, you can use [Glyphicons] that are packaged with Bootstrap.
 
-If Font Awesome is not already included in the consuming application, add the following to your applications `config/environment.js` file as a property of the `ENV` object.
+If Font Awesome is not already included in the consuming application, the addon can add it via Bower. Glyphicons can **not** be added to your application via this addon.
+
+Add the following to your applications `config/environment.js` file as a property of the `ENV` object.
 
 ```js
 var ENV = {
   'ember-cli-notifications': {
-    includeFontAwesome: true
+    icons: 'font-awesome', // Or 'bootstrap'
+    importFontAwesome: true
   }
 }
 ```
@@ -105,7 +117,7 @@ The string that is displayed within the notification. This is the only **require
 
 ```js
 this.notifications.addNotification({
-    message: 'Successfully saved your settings'
+  message: 'Successfully saved your settings'
 });
 ```
 
@@ -126,8 +138,8 @@ Define the type of notification that should be presented. This sets the CSS of t
 
 ```js
 this.notifications.addNotification({
-    message: 'Successfully saved your settings',
-    type: 'success'
+  message: 'Successfully saved your settings',
+  type: 'success'
 });
 ```
 
@@ -148,9 +160,9 @@ If true, inherits the default `clearDuration` value unless specified.
 
 ```js
 this.notifications.addNotification({
-    message: 'Successfully saved your settings',
-    type: 'success',
-    autoClear: true
+  message: 'Successfully saved your settings',
+  type: 'success',
+  autoClear: true
 });
 ```
 
@@ -164,17 +176,11 @@ The time in milliseconds that the notification will automatically dismiss after,
 
 ```js
 this.notifications.addNotification({
-    message: 'Successfully saved your settings',
-    type: 'success',
-    autoClear: true,
-    clearDuration: 1200
+  message: 'Successfully saved your settings',
+  type: 'success',
+  autoClear: true,
+  clearDuration: 1200
 });
-```
-
-#### Change the default duration time
-```js
-//this code only needs to be called in one place such as your application route
-this.notifications.setDefaultClearNotification(1000);
 ```
 
 [Ember CLI]: http://ember-cli.com
@@ -182,3 +188,4 @@ this.notifications.setDefaultClearNotification(1000);
 [demo]: http://blooie.github.io/ember-cli-notifications
 [broccoli-sass]: https://www.npmjs.com/package/broccoli-sass
 [Font Awesome]: http://fortawesome.github.io/Font-Awesome
+[Glyphicons]: http://getbootstrap.com/components/#glyphicons

--- a/README.md
+++ b/README.md
@@ -92,17 +92,16 @@ Include this snippet in your Handlebars template to display the notifications.
 
 ## Icons
 
-By default, [Font Awesome] is used for the message type icons on the notifications. Alternatively, you can use [Glyphicons] that are packaged with Bootstrap.
+By default, [Font Awesome] is used by the addon for the message type icons and is added to the consuming application via Bower.
 
-If Font Awesome is not already included in the consuming application, the addon can add it via Bower. Glyphicons can **not** be added to your application via this addon.
+Alternatively, you can use [Glyphicons] that are packaged with Bootstrap. Glyphicons are **not** added to your application via this addon.
 
 Add the following to your applications `config/environment.js` file as a property of the `ENV` object.
 
 ```js
 var ENV = {
   'ember-cli-notifications': {
-    icons: 'font-awesome', // Or 'bootstrap'
-    importFontAwesome: true
+    icons: 'bootstrap'
   }
 }
 ```

--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -1,37 +1,58 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-    classNameBindings: [':c-notification', 'processedType', 'notification.dismiss::c-notification--in', 'autoClear::c-notification--dismissable'],
+  classNames: ['c-notification'],
+  classNameBindings: [
+    'processedType',
+    'notification.dismiss::c-notification--in',
+    'autoClear::c-notification--dismissable'
+  ],
 
-    // Set icon depending on notification type
-    notificationIcon: Ember.computed('notification.type', function() {
-        switch(this.get('notification.type')){
-            case "info":
-                return 'fa-info-circle';
-            case "success":
-                return 'fa-check';
-            case "warning":
-                return 'fa-warning';
-            case "error":
-                return 'fa-exclamation-circle';
-        }
-    }),
+  // Set icon depending on notification type
+  notificationIcon: Ember.computed('notification.type', 'theme', function() {
+    var icons = this.get('icons');
 
-    processedType: Ember.computed('notification.type', function() {
-      if(this.get('notification.type') && Ember.A(['info', 'success', 'warning', 'error']).contains(this.get('notification.type'))){
-        return "c-notification--" + this.get('notification.type');
+    if (icons === 'font-awesome') {
+      switch(this.get('notification.type')){
+        case "info":
+          return 'fa fa-info-circle';
+        case "success":
+          return 'fa fa-check';
+        case "warning":
+          return 'fa fa-warning';
+        case "error":
+          return 'fa fa-exclamation-circle';
       }
-    }),
-
-    // Apply the clear animation duration rule inline
-    notificationClearDuration: Ember.computed('notification.clearDuration', function() {
-        var duration = Ember.Handlebars.Utils.escapeExpression(this.get('notification.clearDuration'));
-        return Ember.String.htmlSafe(`animation-duration: ${duration}ms; -webkit-animation-duration: ${duration}ms`);
-    }),
-
-    actions: {
-        removeNotification: function() {
-            this.notifications.removeNotification(this.get('notification'));
-        }
     }
+
+    if (icons === 'bootstrap') {
+      switch(this.get('notification.type')){
+        case "info":
+          return 'glyphicon glyphicon-info-sign';
+        case "success":
+          return 'glyphicon glyphicon-ok-sign';
+        case "warning":
+        case "error":
+          return 'glyphicon glyphicon-exclamation-sign';
+      }
+    }
+  }),
+
+  processedType: Ember.computed('notification.type', function() {
+    if(this.get('notification.type') && Ember.A(['info', 'success', 'warning', 'error']).contains(this.get('notification.type'))){
+      return "c-notification--" + this.get('notification.type');
+    }
+  }),
+
+  // Apply the clear animation duration rule inline
+  notificationClearDuration: Ember.computed('notification.clearDuration', function() {
+    var duration = Ember.Handlebars.Utils.escapeExpression(this.get('notification.clearDuration'));
+    return Ember.String.htmlSafe(`animation-duration: ${duration}ms; -webkit-animation-duration: ${duration}ms`);
+  }),
+
+  actions: {
+    removeNotification() {
+      this.notifications.removeNotification(this.get('notification'));
+    }
+  }
 });

--- a/app/components/notification-message.js
+++ b/app/components/notification-message.js
@@ -4,5 +4,5 @@ import ENV from '../config/environment';
 var config = ENV['ember-cli-notifications'] || {};
 
 export default NotificationMessage.extend({
-  icons: config.icons
+  icons: config.icons || 'font-awesome'
 });

--- a/app/components/notification-message.js
+++ b/app/components/notification-message.js
@@ -1,3 +1,8 @@
 import NotificationMessage from 'ember-cli-notifications/components/notification-message';
+import ENV from '../config/environment';
 
-export default NotificationMessage;
+var config = ENV['ember-cli-notifications'] || {};
+
+export default NotificationMessage.extend({
+  icons: config.icons
+});

--- a/app/templates/components/notification-message.hbs
+++ b/app/templates/components/notification-message.hbs
@@ -1,6 +1,8 @@
 <div class="c-notification__icon">
   <span>
-    <i class="fa {{notificationIcon}}"></i>
+    {{#if icons}}
+      <i class="{{notificationIcon}}"></i>
+    {{/if}}
   </span>
 </div>
 <div class="c-notification__content">

--- a/blueprints/ember-cli-notifications/index.js
+++ b/blueprints/ember-cli-notifications/index.js
@@ -9,10 +9,8 @@ module.exports = {
     var projectConfig = this.project.config(app.env);
     var config = projectConfig['ember-cli-notifications'];
 
-    if (config) {
-      if (config.importFontAwesome) {
-        return this.addBowerPackageToProject('font-awesome');
-      }
+    if (!config || config.icons !== 'bootstrap') {
+      return this.addBowerPackageToProject('font-awesome');
     }
   }
 };

--- a/blueprints/ember-cli-notifications/index.js
+++ b/blueprints/ember-cli-notifications/index.js
@@ -2,19 +2,17 @@
 'use strict';
 
 module.exports = {
-    normalizeEntityName: function() {},
+  normalizeEntityName: function() {},
 
-    // Use config to determine whether Font Awesome is imported into consuming app
-    afterInstall: function(app) {
-        var projectConfig = this.project.config(app.env);
-        var config = projectConfig['ember-cli-notifications'];
+  // Use config to determine whether Font Awesome is imported into consuming app
+  afterInstall: function(app) {
+    var projectConfig = this.project.config(app.env);
+    var config = projectConfig['ember-cli-notifications'];
 
-        if (config) {
-            var include = config.includeFontAwesome;
-
-            if (include) {
-                return this.addBowerPackageToProject('font-awesome');
-            }
-        }
+    if (config) {
+      if (config.importFontAwesome) {
+        return this.addBowerPackageToProject('font-awesome');
+      }
     }
+  }
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,12 +1,12 @@
 'use strict';
 
 module.exports = function(environment) {
-    var ENV = {
-        // Allow inline styling for animation duration
-        contentSecurityPolicy: {
-            'style-src': "'self' 'unsafe-inline'",
-        }
-    };
+  var ENV = {
+    // Allow inline styling for animation duration
+    contentSecurityPolicy: {
+      'style-src': "'self' 'unsafe-inline'",
+    }
+  };
 
-    return ENV;
+  return ENV;
 };

--- a/index.js
+++ b/index.js
@@ -14,25 +14,23 @@ module.exports = {
     var projectConfig = this.project.config(app.env);
     var config = projectConfig['ember-cli-notifications'];
 
-    if (config) {
-      if (config.importFontAwesome) {
-        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.eot', {
-          destDir: 'fonts'
-        });
-        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.svg', {
-          destDir: 'fonts'
-        });
-        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.ttf', {
-          destDir: 'fonts'
-        });
-        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff', {
-          destDir: 'fonts'
-        });
-        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff2', {
-          destDir: 'fonts'
-        });
-        app.import(app.bowerDirectory + '/font-awesome/css/font-awesome.css');
-      }
+    if (!config || config.icons !== 'bootstrap') {
+      app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.eot', {
+        destDir: 'fonts'
+      });
+      app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.svg', {
+        destDir: 'fonts'
+      });
+      app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.ttf', {
+        destDir: 'fonts'
+      });
+      app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff', {
+        destDir: 'fonts'
+      });
+      app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff2', {
+        destDir: 'fonts'
+      });
+      app.import(app.bowerDirectory + '/font-awesome/css/font-awesome.css');
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
     this.importFontAwesome(app);
   },
 
-  importFontAwesome(app) {
+  importFontAwesome: function(app) {
     var projectConfig = this.project.config(app.env);
     var config = projectConfig['ember-cli-notifications'];
 

--- a/index.js
+++ b/index.js
@@ -2,39 +2,37 @@
 'use strict';
 
 module.exports = {
-    name: 'ember-cli-notifications',
-    included: function(app) {
-        this._super.included(app);
+  name: 'ember-cli-notifications',
+  included: function(app) {
+    this._super.included(app);
 
-        // Use config to determine whether Font Awesome is imported into consuming app
-        this.importFontAwesome(app);
-    },
+    // Use config to determine whether Font Awesome is imported into consuming app
+    this.importFontAwesome(app);
+  },
 
-    importFontAwesome: function(app) {
-        var projectConfig = this.project.config(app.env);
-        var config = projectConfig['ember-cli-notifications'];
+  importFontAwesome(app) {
+    var projectConfig = this.project.config(app.env);
+    var config = projectConfig['ember-cli-notifications'];
 
-        if (config) {
-            var include = config.includeFontAwesome;
-
-            if (include) {
-                app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.eot', {
-                    destDir: 'fonts'
-                });
-                app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.svg', {
-                    destDir: 'fonts'
-                });
-                app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.ttf', {
-                    destDir: 'fonts'
-                });
-                app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff', {
-                    destDir: 'fonts'
-                });
-                app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff2', {
-                    destDir: 'fonts'
-                });
-                app.import(app.bowerDirectory + '/font-awesome/css/font-awesome.css');
-            }
-        }
+    if (config) {
+      if (config.importFontAwesome) {
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.eot', {
+          destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.svg', {
+          destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.ttf', {
+          destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff', {
+          destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.woff2', {
+          destDir: 'fonts'
+        });
+        app.import(app.bowerDirectory + '/font-awesome/css/font-awesome.css');
+      }
     }
+  }
 };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -18,11 +18,6 @@ module.exports = function(environment) {
       // when it is created
     },
 
-    'ember-cli-notifications': {
-      icons: 'font-awesome',
-      importFontAwesome: true
-    },
-
     // Allow inline styling for animation duration
     contentSecurityPolicy: {
       'style-src': "'self' 'unsafe-inline'",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,12 +19,13 @@ module.exports = function(environment) {
     },
 
     'ember-cli-notifications': {
-        includeFontAwesome: true
+      icons: 'font-awesome',
+      importFontAwesome: true
     },
 
     // Allow inline styling for animation duration
     contentSecurityPolicy: {
-        'style-src': "'self' 'unsafe-inline'",
+      'style-src': "'self' 'unsafe-inline'",
     }
   };
 


### PR DESCRIPTION
- New key in config object that accepts a string for icon family options (`font-awesome` or `bootstrap`)
- Appropriate class names applied to template depending on selection
- Font Awesome is still packaged with add-on, ~~but must be imported into consuming app via config~~ is imported to consuming app unless `bootstrap` is set in config.
- Bootstrap icons are not a part of the add-on.

Fixes #45.
