### PR TITLE
Make inclusion of the font-awesome assets in project configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,19 @@ Include this snippet in your Handlebars template to display the notifications.
 
 ## Icons
 
-By default, [Font Awesome] is used by the addon for the message type icons and is added to the consuming application via Bower.
+[Font Awesome] is required as part of the addon to display the message type icons on the notifications.
+
+If Font Awesome is not already included in the consuming application, add the following to your applications `config/environment.js` file as a property of the `ENV` object.
+
+```js
+var ENV = {
+  'ember-cli-notifications': {
+    includeFontAwesome: true
+  }
+}
+```
 
 Alternatively, you can use [Glyphicons] that are packaged with Bootstrap. Glyphicons are **not** added to your application via this addon.
-
-Add the following to your applications `config/environment.js` file as a property of the `ENV` object.
 
 ```js
 var ENV = {

--- a/app/components/notification-message.js
+++ b/app/components/notification-message.js
@@ -1,8 +1,9 @@
 import NotificationMessage from 'ember-cli-notifications/components/notification-message';
 import ENV from '../config/environment';
 
-var config = ENV['ember-cli-notifications'] || {};
+var config = ENV['ember-cli-notifications'] ||
+             { icons: 'font-awesome' };
 
 export default NotificationMessage.extend({
-  icons: config.icons || 'font-awesome'
+  icons: config.icons
 });

--- a/blueprints/ember-cli-notifications/index.js
+++ b/blueprints/ember-cli-notifications/index.js
@@ -7,9 +7,10 @@ module.exports = {
   // Use config to determine whether Font Awesome is imported into consuming app
   afterInstall: function(app) {
     var projectConfig = this.project.config(app.env);
-    var config = projectConfig['ember-cli-notifications'];
+    var config = projectConfig['ember-cli-notifications'] ||
+                 { includeFontAwesome: false };
 
-    if (!config || config.icons !== 'bootstrap') {
+    if (config.includeFontAwesome) {
       return this.addBowerPackageToProject('font-awesome');
     }
   }

--- a/index.js
+++ b/index.js
@@ -12,9 +12,10 @@ module.exports = {
 
   importFontAwesome: function(app) {
     var projectConfig = this.project.config(app.env);
-    var config = projectConfig['ember-cli-notifications'];
+    var config = projectConfig['ember-cli-notifications'] ||
+                 { includeFontAwesome: false };
 
-    if (!config || config.icons !== 'bootstrap') {
+    if (config.includeFontAwesome) {
       app.import(app.bowerDirectory + '/font-awesome/fonts/fontawesome-webfont.eot', {
         destDir: 'fonts'
       });


### PR DESCRIPTION
This PR implements a `incudeFontAwesome` option on `ember-cli-config.js` (or `Brocfile.js`) to enable or disable inclusion. Currently the default is **not** to include `font-awesome` but if needed I could set it to include by default and update this PR.

Fixes #52
