### PR TITLE
Simplify template code with {{notification-container}} component

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,7 @@ this.notifications.setDefaultClearNotification(1000);
 Include this snippet in your Handlebars template to display the notifications.
 
 ```hbs
-<div class="c-notification__container">
-  {{#each notifications as |notification|}}
-    {{notification-message notification=notification}}
-  {{/each}}
-</div>
+{{notification-container notifications=notifications}}
 ```
 
 ## Icons

--- a/app/templates/components/notification-container.hbs
+++ b/app/templates/components/notification-container.hbs
@@ -1,0 +1,5 @@
+<div class="c-notification__container">
+  {{#each notifications as |notification|}}
+    {{notification-message notification=notification}}
+  {{/each}}
+</div>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,8 +1,5 @@
-<div class="c-notification__container">
-  {{#each notifications as |notification|}}
-    {{notification-message notification=notification}}
-  {{/each}}
-</div>
+{{notification-container notifications=notifications}}
+
 <h2>ember-cli-notifications</h2>
 <div class="mb2">
   <h3>Message</h3>


### PR DESCRIPTION
This PR add a `{{notification-container}}` component which reduces the code that users have to paste into their own templates down to a single component.
