### PR TITLE
onClick fix + new onClose callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ actions: {
   }
 }
 ```
+
+### Callback for closing a notification (by clicking on the cross icon on the right)
+```js
+actions: {
+  saveOptions() {
+    this.get('model').save()
+    .then(() => {
+      this.notifications.success('Successfully saved your settings', {
+        onClose: function(notification){
+          alert('Notification closed');
+        }
+      });
+    });
+  }
+}
+```
+
 ### Remove all active notifications using clearAll() before adding a new notification
 
 ```js

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ actions: {
 }
 ```
 
+### Add a notification with HTML content
+
+```js
+actions: {
+  saveOptions() {
+    this.get('model').save()
+    .then(() => {
+      this.notifications.success('<b>Successfully</b> <u>saved</u> your settings', {
+        htmlContent: true
+      });
+    }),
+    .catch((err) => {
+      this.notifications.error('Something went wrong');
+    });
+  }
+}
+```
+
 ### Set a global, default duration time
 
 This code only needs to be called in one place such as your application route.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ actions: {
 
 ### Add a notification with HTML content
 
+*Warning:* this introduces a potential security risk, since notification message will no longer be escaped by Ember (only when _htmlContent_ option is enabled).
+
 ```js
 actions: {
   saveOptions() {

--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -45,8 +45,11 @@ export default Ember.Component.extend({
     }
   }),
 
-  mouseDown() {
-    if (this.get('notification.onClick')) {
+  mouseDown(element) {
+    //when close button (or any of its children) is clicked, do not call onClick callback
+    let removeNotificationClicked = Ember.$(element.target).closest('.c-notification__close').length !== 0;
+
+    if (this.get('notification.onClick') && !removeNotificationClicked) {
       this.get('notification.onClick')(this.get('notification'));
     }
   },
@@ -79,6 +82,10 @@ export default Ember.Component.extend({
 
   actions: {
     removeNotification() {
+      if ( this.get('notification.onClose')){
+        this.get('notification.onClose')(this.get('notification'));
+      }
+
       this.notifications.removeNotification(this.get('notification'));
     }
   }

--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -18,6 +18,7 @@ export default Ember.ArrayProxy.extend({
             autoClear: (Ember.isEmpty(options.autoClear) ? this.get('defaultAutoClear') : options.autoClear),
             clearDuration: options.clearDuration || this.get('defaultClearDuration'),
             onClick: options.onClick,
+            onClose: options.onClose,
             htmlContent: options.htmlContent || false
         });
 

--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -17,7 +17,8 @@ export default Ember.ArrayProxy.extend({
             type: options.type || 'info', // info, success, warning, error
             autoClear: (Ember.isEmpty(options.autoClear) ? this.get('defaultAutoClear') : options.autoClear),
             clearDuration: options.clearDuration || this.get('defaultClearDuration'),
-            onClick: options.onClick
+            onClick: options.onClick,
+            htmlContent: options.htmlContent || false
         });
 
         this.pushObject(notification);

--- a/app/templates/components/notification-message.hbs
+++ b/app/templates/components/notification-message.hbs
@@ -4,7 +4,11 @@
   </span>
 </div>
 <div class="c-notification__content">
-  {{notification.message}}
+  {{#if notification.htmlContent}}
+    {{{notification.message}}}
+  {{else}}
+    {{notification.message}}
+  {{/if}}
 </div>
 {{#if notification.autoClear}}
   <div class="c-notification__countdown" style={{notificationClearDuration}}></div>

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -28,7 +28,7 @@
   "boss": true,
   "curly": true,
   "debug": false,
-  "devel": false,
+  "devel": true,
   "eqeqeq": true,
   "evil": true,
   "forin": false,

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -17,7 +17,13 @@ export default Ember.Controller.extend({
         type: this.get('type'),
         autoClear: this.get('autoClear'),
         clearDuration: this.get('clearDuration'),
-        htmlContent: this.get('htmlContent')
+        htmlContent: this.get('htmlContent'),
+        onClick: function(){
+          alert('Yes, you clicked on me! I hope, you are happy now :()');
+        },
+        onClose: function(){
+          alert('Noooooo, why did you close me?');
+        }
       });
     }
   }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -5,6 +5,7 @@ export default Ember.Controller.extend({
   type: 'success',
   autoClear: true,
   clearDuration: 2400,
+  htmlContent: false,
 
   actions: {
     showNotifcation() {
@@ -15,7 +16,8 @@ export default Ember.Controller.extend({
         message: this.get('message'),
         type: this.get('type'),
         autoClear: this.get('autoClear'),
-        clearDuration: this.get('clearDuration')
+        clearDuration: this.get('clearDuration'),
+        htmlContent: this.get('htmlContent')
       });
     }
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -50,5 +50,9 @@
   </div>
 </div>
 
+<div>
+  Note: try to click on the notification or the "close" button - custom event handlers were will be triggered, too.
+</div>
+
 <button class="button" {{action "showNotifcation"}}>Show</button>
 {{outlet}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -41,5 +41,14 @@
     <label>Clear all</label>
   </div>
 </div>
+
+<div class="mb2">
+  <h3>HTML content</h3>
+  <div class="mb2">
+    {{input type="checkbox" checked=htmlContent}}
+    <label>Enable HMTL</label>
+  </div>
+</div>
+
 <button class="button" {{action "showNotifcation"}}>Show</button>
 {{outlet}}


### PR DESCRIPTION
Hi,
I noticed, that when onClick callback is defined and user clicks on the close icon, the onClick callback is triggered. I am not sure if it is desired or not, but I don't like this behavior :) Usually close button basically means "ignore the notification and carry on" - by triggering the callback you are basically performing an action that user wanted to ignore.

So I fixed it (onClick callback will be triggered when clicking anywhere on the notification except the close icon) + I added new onClose callback that will be triggered when user closes the notification

btw. I know that the way I fixed the onClick callback in method `mouseDown()` is not very nice (jQuery...), but it works anyway...
