### PR TITLE
[BREAKING] change: Update service initializer and delete deprecated

### DIFF
--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const assign = Ember.assign || Ember.merge;
+
 export default Ember.ArrayProxy.extend({
     content: Ember.A(),
 
@@ -33,28 +35,28 @@ export default Ember.ArrayProxy.extend({
 
     // Helper methods for each type of notification
     error(message, options) {
-      this.addNotification(Ember.merge({
+      this.addNotification(assign({
         message: message,
         type: 'error'
       }, options));
     },
 
     success(message, options) {
-      this.addNotification(Ember.merge({
+      this.addNotification(assign({
         message: message,
         type: 'success'
       }, options));
     },
 
     info(message, options) {
-      this.addNotification(Ember.merge({
+      this.addNotification(assign({
         message: message,
         type: 'info'
       }, options));
     },
 
     warning(message, options) {
-      this.addNotification(Ember.merge({
+      this.addNotification(assign({
         message: message,
         type: 'warning'
       }, options));

--- a/app/initializers/notifications.js
+++ b/app/initializers/notifications.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import NotificationMessagesService from 'ember-cli-notifications/services/notification-messages-service';
 
 export default {
@@ -5,6 +6,11 @@ export default {
 
     initialize() {
         let application = arguments[1] || arguments[0];
+        if (Ember.Service) {
+          application.register('service:notification-messages', NotificationMessagesService);
+          application.inject('component:notification-message', 'notifications', 'service:notification-messages');
+          return;
+        }
         application.register('notification-messages:service', NotificationMessagesService);
 
         ['controller', 'component', 'route', 'router', 'service'].forEach(injectionTarget => {

--- a/app/initializers/notifications.js
+++ b/app/initializers/notifications.js
@@ -8,6 +8,7 @@ export default {
         let application = arguments[1] || arguments[0];
         if (Ember.Service) {
           application.register('service:notification-messages', NotificationMessagesService);
+          application.inject('component:notification-container', 'notifications', 'service:notification-messages');
           application.inject('component:notification-message', 'notifications', 'service:notification-messages');
           return;
         }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-notifications",
   "dependencies": {
-    "ember": "^2.5.1",
+    "ember": "^2.6.0",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-notifications",
   "dependencies": {
-    "ember": "~2.4.3",
+    "ember": "^2.5.1",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.4.2",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -9,6 +9,8 @@ export default Ember.Controller.extend({
   htmlContent: false,
   position: 'top',
 
+  notifications: Ember.inject.service('notification-messages'),
+
   disableTimeoutInput: Ember.computed.not('autoClear'),
 
   computedMessage: Ember.computed('htmlContent', function() {
@@ -20,9 +22,9 @@ export default Ember.Controller.extend({
   actions: {
     showNotifcation() {
       if (this.get('clearAll')) {
-        this.notifications.clearAll();
+        this.get('notifications').clearAll();
       }
-      this.notifications.addNotification({
+      this.get('notifications').addNotification({
         message: this.get('computedMessage'),
         type: this.get('type'),
         autoClear: this.get('autoClear'),

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,11 +2,13 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
+const assign = Ember.assign || Ember.merge;
+
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = assign({}, config.APP);
+  attributes = assign(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
fixes #80 #60

add support for Ember.inject.service for a new Ember's versions

If you need access to `notification-messages` service, inject it as a service:

```
export default Ember.Controller.extend({
  notifications: Ember.inject.service('notification-messages'),
});
```
