### PR TITLE
Remove 'DEPRECATION' warning

### DIFF
--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -33,28 +33,28 @@ export default Ember.ArrayProxy.extend({
 
     // Helper methods for each type of notification
     error(message, options) {
-      this.addNotification(Ember.merge({
+      this.addNotification(Ember.assign({
         message: message,
         type: 'error'
       }, options));
     },
 
     success(message, options) {
-      this.addNotification(Ember.merge({
+      this.addNotification(Ember.assign({
         message: message,
         type: 'success'
       }, options));
     },
 
     info(message, options) {
-      this.addNotification(Ember.merge({
+      this.addNotification(Ember.assign({
         message: message,
         type: 'info'
       }, options));
     },
 
     warning(message, options) {
-      this.addNotification(Ember.merge({
+      this.addNotification(Ember.assign({
         message: message,
         type: 'warning'
       }, options));


### PR DESCRIPTION
Remove DEPRECATION warning about 'Ember.merge'

ember-cli: 2.4.3
ember: 2.5.0
