### PR TITLE
Add documentation for injector initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Interactive documentation can be found [here].
 notifications: Ember.inject.service('notification-messages')
 ```
 
+See the documentation for a sample initializer to inject the service in all controllers.
+
 ## Installation
 
 ```shell

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -34,8 +34,20 @@ ember install ember-cli-notifications
     {{/themed-syntax}}
 
     <p>Inject the notifications service where required.</p>
-    {{#themed-syntax lang="htmlbars" theme="dark" class="h5" withBuffers=false}}
+    {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
 notifications: Ember.inject.service('notification-messages')
+    {{/themed-syntax}}
+
+    <p>Or inject it everywhere with an initializer (app/initializers/inject-notifications.js):</p>
+    {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+export function initialize(application) {
+  application.inject('controller', 'notifications', 'service:notification-messages');
+}
+
+export default {
+  name: 'inject-notifications',
+  initialize
+};
     {{/themed-syntax}}
 
     <p>There are four styles of notification available.</p>


### PR DESCRIPTION
This PR adds documentation on how to implement an initializer to inject the service in all the controllers. For me this was the major pain point updating from 3.X to 4.X, I was using the notifications everywhere and adding it manually to lots of controllers would have been a lot of work.  
