### PR TITLE
add fluent syntax to notification messages service

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,9 @@
 ![Download count all time](https://img.shields.io/npm/dt/ember-cli-notifications.svg)
 [![NPM package](https://img.shields.io/npm/v/ember-cli-notifications.svg)](https://www.npmjs.com/package/ember-cli-notifications) [![Build Status](https://img.shields.io/travis/stonecircle/ember-cli-notifications.svg)](https://travis-ci.org/stonecircle/ember-cli-notifications) [![Ember Observer Score](http://emberobserver.com/badges/ember-cli-notifications.svg)](http://emberobserver.com/addons/ember-cli-notifications)
 
-
 An [Ember CLI] addon that adds [Atom] inspired notification messages to your app.
 
 Interactive documentation can be found [here].
-
-**As of 4.0.0 the addon is now service based. You will need to inject the service into your consuming app.**
-
-```js
-notifications: Ember.inject.service('notification-messages')
-```
-
-See the documentation for a sample initializer to inject the service in all controllers.
 
 ## Installation
 
@@ -22,6 +13,17 @@ See the documentation for a sample initializer to inject the service in all cont
 ember install ember-cli-notifications
 ```
 
+## 4.0.0
+
+As of 4.0.0, the addon is service based. You will need to inject the service into your consuming app.
+
+```js
+notifications: Ember.inject.service('notification-messages')
+```
+
+See the [documentation] for a sample initializer to inject the service into all controllers, routes and components.
+
 [Ember CLI]: http://ember-cli.com
 [Atom]: https://github.com/atom/notifications
 [here]: http://stonecircle.github.io/ember-cli-notifications
+[documentation]: http://stonecircle.github.io/ember-cli-notifications

--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -1,12 +1,23 @@
 import Ember from 'ember';
+import config from 'ember-get-config';
 
 const assign = Ember.assign || Ember.merge;
+const globals = config['ember-cli-notifications']; // Import app config object
+
+// Set global values for user configurable options
+function setGlobal(property, value) {
+  // If the value exists in app config object, set that as global
+  if (property) return property;
+
+  // Otherwise return the default value
+  return value;
+}
 
 export default Ember.ArrayProxy.extend({
     content: Ember.A(),
 
-    defaultClearDuration: 3200,
-    defaultAutoClear: false,
+    globalAutoClear: setGlobal(globals.autoClear, false),
+    globalClearDuration: setGlobal(globals.clearDuration, 3200),
 
     addNotification(options) {
         // If no message is set, throw an error
@@ -17,8 +28,8 @@ export default Ember.ArrayProxy.extend({
         const notification = Ember.Object.create({
             message: options.message,
             type: options.type || 'info', // info, success, warning, error
-            autoClear: (Ember.isEmpty(options.autoClear) ? this.get('defaultAutoClear') : options.autoClear),
-            clearDuration: options.clearDuration || this.get('defaultClearDuration'),
+            autoClear: (Ember.isEmpty(options.autoClear) ? this.get('globalAutoClear') : options.autoClear),
+            clearDuration: options.clearDuration || this.get('globalClearDuration'),
             onClick: options.onClick,
             htmlContent: options.htmlContent || false
         });
@@ -96,21 +107,5 @@ export default Ember.ArrayProxy.extend({
 
     clearAll() {
         this.set('content', Ember.A());
-    },
-
-    setDefaultAutoClear(autoClear) {
-      if (Ember.typeOf(autoClear) !== 'boolean') {
-        throw new Error('Default auto clear preference must be a boolean');
-      }
-
-      this.set('defaultAutoClear', autoClear);
-    },
-
-    setDefaultClearNotification(clearDuration) {
-      if (Ember.typeOf(clearDuration) !== 'number') {
-        throw new Error('Clear duration must be a number');
-      }
-
-      this.set('defaultClearDuration', clearDuration);
     }
 });

--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -39,6 +39,7 @@ export default Ember.ArrayProxy.extend({
         message: message,
         type: 'error'
       }, options));
+      return this;
     },
 
     success(message, options) {
@@ -46,6 +47,7 @@ export default Ember.ArrayProxy.extend({
         message: message,
         type: 'success'
       }, options));
+      return this;
     },
 
     info(message, options) {
@@ -53,6 +55,7 @@ export default Ember.ArrayProxy.extend({
         message: message,
         type: 'info'
       }, options));
+      return this;
     },
 
     warning(message, options) {
@@ -60,6 +63,7 @@ export default Ember.ArrayProxy.extend({
         message: message,
         type: 'warning'
       }, options));
+      return this;
     },
 
     removeNotification(notification) {
@@ -96,6 +100,7 @@ export default Ember.ArrayProxy.extend({
 
     clearAll() {
         this.set('content', Ember.A());
+        return this;
     },
 
     setDefaultAutoClear(autoClear) {
@@ -104,6 +109,7 @@ export default Ember.ArrayProxy.extend({
       }
 
       this.set('defaultAutoClear', autoClear);
+      return this;
     },
 
     setDefaultClearNotification(clearDuration) {
@@ -112,5 +118,6 @@ export default Ember.ArrayProxy.extend({
       }
 
       this.set('defaultClearDuration', clearDuration);
+      return this;
     }
 });

--- a/app/components/notification-message.js
+++ b/app/components/notification-message.js
@@ -1,7 +1,7 @@
 import NotificationMessage from 'ember-cli-notifications/components/notification-message';
 import ENV from '../config/environment';
 
-let config = ENV['ember-cli-notifications'] || {};
+const config = ENV['ember-cli-notifications'] || {};
 
 export default NotificationMessage.extend({
   icons: config.icons || 'font-awesome'

--- a/app/services/notification-messages-service.js
+++ b/app/services/notification-messages-service.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-notifications/services/notification-messages-service';

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-data": "^2.7.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-get-config": "0.1.11",
     "ember-load-initializers": "^0.5.1",
     "ember-radio-button": "1.0.7",
     "ember-resolver": "^2.0.3",

--- a/tests/dummy/app/services/notifications.js
+++ b/tests/dummy/app/services/notifications.js
@@ -1,0 +1,5 @@
+import NotificationsService from 'ember-cli-notifications/services/notification-messages-service';
+
+export default NotificationsService.extend({
+  // Extend the imported service
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -244,6 +244,20 @@ var ENV = {
 }
     {{/themed-syntax}}
   </div>
+  <div class="py2">
+    <h2>Extend</h2>
+    <hr>
+    <p>The <b>notification-messages-service</b> service can be imported into the consuming app and extended.</p>
+    {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+// app/services/notifications.js
+import NotificationsService from 'ember-cli-notifications/services/notification-messages-service';
+
+export default NotificationsService.extend({
+  // Extend the imported service
+});
+    {{/themed-syntax}}
+    <p>Be sure to inject the <i>new</i> service into your app.</p>
+  </div>
 </div>
 <footer class="bg-darken-1 py3">
   <div class="max-width-4 mx-auto px2">

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -38,10 +38,13 @@ ember install ember-cli-notifications
 notifications: Ember.inject.service('notification-messages')
     {{/themed-syntax}}
 
-    <p>Or inject it everywhere with an initializer (app/initializers/inject-notifications.js):</p>
+    <p>Or inject it everywhere with an initializer.</p>
     {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+// app/initializers/inject-notifications.js
 export function initialize(application) {
-  application.inject('controller', 'notifications', 'service:notification-messages');
+  ['controller', 'route', 'component'].forEach(injectionTarget => {
+    application.inject(injectionTarget, 'notifications', 'service:notification-messages');
+  });
 }
 
 export default {
@@ -150,10 +153,6 @@ this.get('notifications').success('Saved successfully!', {
   autoClear: true
 });
     {{/themed-syntax}}
-    <p>Set a global default value.</p>
-    {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
-this.get('notifications').setDefaultAutoClear(true);
-    {{/themed-syntax}}
 
     <h3>clearDuration</h3>
     <p>Specify a duration (ms) before the notification clears. This will take precedence over the global default value.</p>
@@ -163,10 +162,6 @@ this.get('notifications').success('Saved successfully!', {
   autoClear: true,
   clearDuration: 1200
 });
-    {{/themed-syntax}}
-    <p>Set a global default value.</p>
-    {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
-this.get('notifications').setDefaultClearNotification(1200);
     {{/themed-syntax}}
 
     <h3>clearAll</h3>
@@ -213,12 +208,24 @@ this.get('notifications').error('Something went wrong. Click to try again', {
   <div class="py2">
     <h2>Config</h2>
     <hr>
+    <h3>Globals</h3>
+    <p>Set the global default values for <b>autoClear</b> and <b>clearDuration</b>.</p>
+    {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+// config/environment.js
+var ENV = {
+  'ember-cli-notifications': {
+    autoClear: true,
+    clearDuration: 2400
+  }
+}
+    {{/themed-syntax}}
     <h3>Icons</h3>
     <p><a href="http://fontawesome.io/" target="_blank">Font Awesome</a> is a requirement to display the icons on the notifications.</p>
 
     <p>If Font Awesome is not already included in the consuming application, add the following to your environment config file.</p>
 
     {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+// config/environment.js
 var ENV = {
   'ember-cli-notifications': {
     includeFontAwesome: true
@@ -229,6 +236,7 @@ var ENV = {
     <p>Alternatively, the notifications can use the <a href="http://getbootstrap.com/components/#glyphicons" target="_blank">Glyphicons</a> icon package. Glyphicons will <b>not</b> added to your application via this addon.</p>
 
     {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+// config/environment.js
 var ENV = {
   'ember-cli-notifications': {
     icons: 'bootstrap'

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -18,7 +18,9 @@ module.exports = function(environment) {
       // when it is created
     },
     'ember-cli-notifications': {
-      includeFontAwesome: true
+      includeFontAwesome: true,
+      autoClear: true,
+      clearDuration: 2400
     }
   };
 

--- a/tests/unit/services/notification-messages-service-test.js
+++ b/tests/unit/services/notification-messages-service-test.js
@@ -1,0 +1,18 @@
+import NotificationMessages from 'ember-cli-notifications/services/notification-messages-service';
+import { module, test } from 'qunit';
+
+module('Unit | Service | notification messages');
+
+test('it supports fluent syntax', function(assert) {
+  const msg = 'returns notification message service';
+  const service = NotificationMessages.create();
+
+  assert.equal(service.error('test'), service, msg);
+  assert.equal(service.info('test'), service, msg);
+  assert.equal(service.success('test'), service, msg);
+  assert.equal(service.warning('test'), service, msg);
+  assert.equal(service.warning('test'), service, msg);
+  assert.equal(service.clearAll(), service, msg);
+  assert.equal(service.setDefaultAutoClear(true), service, msg);
+  assert.equal(service.setDefaultClearNotification(1000), service, msg);
+});

--- a/tests/unit/services/notification-messages-service-test.js
+++ b/tests/unit/services/notification-messages-service-test.js
@@ -13,6 +13,4 @@ test('it supports fluent syntax', function(assert) {
   assert.equal(service.warning('test'), service, msg);
   assert.equal(service.warning('test'), service, msg);
   assert.equal(service.clearAll(), service, msg);
-  assert.equal(service.setDefaultAutoClear(true), service, msg);
-  assert.equal(service.setDefaultClearNotification(1000), service, msg);
 });


### PR DESCRIPTION
jQuery style ergonomics:

**Usage**

```
this.get('notifications')
.success('I')
.info('really')
.warning('like')
.error('notifications')
.clearAll();
```
