### PR TITLE
Allow global values to be defined in app config

### DIFF
--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -1,12 +1,23 @@
 import Ember from 'ember';
+import config from 'ember-get-config';
 
 const assign = Ember.assign || Ember.merge;
+const globals = config['ember-cli-notifications']; // Import app config object
+
+// Set global values for user configurable options
+function setGlobal(property, value) {
+  // If the value exists in app config object, set that as global
+  if (property) return property;
+
+  // Otherwise return the default value
+  return value;
+}
 
 export default Ember.ArrayProxy.extend({
     content: Ember.A(),
 
-    defaultClearDuration: 3200,
-    defaultAutoClear: false,
+    globalAutoClear: setGlobal(globals.autoClear, false),
+    globalClearDuration: setGlobal(globals.clearDuration, 3200),
 
     addNotification(options) {
         // If no message is set, throw an error
@@ -17,8 +28,8 @@ export default Ember.ArrayProxy.extend({
         const notification = Ember.Object.create({
             message: options.message,
             type: options.type || 'info', // info, success, warning, error
-            autoClear: (Ember.isEmpty(options.autoClear) ? this.get('defaultAutoClear') : options.autoClear),
-            clearDuration: options.clearDuration || this.get('defaultClearDuration'),
+            autoClear: (Ember.isEmpty(options.autoClear) ? this.get('globalAutoClear') : options.autoClear),
+            clearDuration: options.clearDuration || this.get('globalClearDuration'),
             onClick: options.onClick,
             htmlContent: options.htmlContent || false
         });
@@ -96,21 +107,5 @@ export default Ember.ArrayProxy.extend({
 
     clearAll() {
         this.set('content', Ember.A());
-    },
-
-    setDefaultAutoClear(autoClear) {
-      if (Ember.typeOf(autoClear) !== 'boolean') {
-        throw new Error('Default auto clear preference must be a boolean');
-      }
-
-      this.set('defaultAutoClear', autoClear);
-    },
-
-    setDefaultClearNotification(clearDuration) {
-      if (Ember.typeOf(clearDuration) !== 'number') {
-        throw new Error('Clear duration must be a number');
-      }
-
-      this.set('defaultClearDuration', clearDuration);
     }
 });

--- a/app/components/notification-message.js
+++ b/app/components/notification-message.js
@@ -1,7 +1,7 @@
 import NotificationMessage from 'ember-cli-notifications/components/notification-message';
 import ENV from '../config/environment';
 
-let config = ENV['ember-cli-notifications'] || {};
+const config = ENV['ember-cli-notifications'] || {};
 
 export default NotificationMessage.extend({
   icons: config.icons || 'font-awesome'

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-data": "^2.7.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-get-config": "0.1.11",
     "ember-load-initializers": "^0.5.1",
     "ember-radio-button": "1.0.7",
     "ember-resolver": "^2.0.3",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -38,10 +38,13 @@ ember install ember-cli-notifications
 notifications: Ember.inject.service('notification-messages')
     {{/themed-syntax}}
 
-    <p>Or inject it everywhere with an initializer (app/initializers/inject-notifications.js):</p>
+    <p>Or inject it everywhere with an initializer.</p>
     {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+// app/initializers/inject-notifications.js
 export function initialize(application) {
-  application.inject('controller', 'notifications', 'service:notification-messages');
+  ['controller', 'route', 'component'].forEach(injectionTarget => {
+    application.inject(injectionTarget, 'notifications', 'service:notification-messages');
+  });
 }
 
 export default {
@@ -150,10 +153,6 @@ this.get('notifications').success('Saved successfully!', {
   autoClear: true
 });
     {{/themed-syntax}}
-    <p>Set a global default value.</p>
-    {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
-this.get('notifications').setDefaultAutoClear(true);
-    {{/themed-syntax}}
 
     <h3>clearDuration</h3>
     <p>Specify a duration (ms) before the notification clears. This will take precedence over the global default value.</p>
@@ -163,10 +162,6 @@ this.get('notifications').success('Saved successfully!', {
   autoClear: true,
   clearDuration: 1200
 });
-    {{/themed-syntax}}
-    <p>Set a global default value.</p>
-    {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
-this.get('notifications').setDefaultClearNotification(1200);
     {{/themed-syntax}}
 
     <h3>clearAll</h3>
@@ -213,12 +208,24 @@ this.get('notifications').error('Something went wrong. Click to try again', {
   <div class="py2">
     <h2>Config</h2>
     <hr>
+    <h3>Globals</h3>
+    <p>Set the global default values for <b>autoClear</b> and <b>clearDuration</b>.</p>
+    {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+// config/environment.js
+var ENV = {
+  'ember-cli-notifications': {
+    autoClear: true,
+    clearDuration: 2400
+  }
+}
+    {{/themed-syntax}}
     <h3>Icons</h3>
     <p><a href="http://fontawesome.io/" target="_blank">Font Awesome</a> is a requirement to display the icons on the notifications.</p>
 
     <p>If Font Awesome is not already included in the consuming application, add the following to your environment config file.</p>
 
     {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+// config/environment.js
 var ENV = {
   'ember-cli-notifications': {
     includeFontAwesome: true
@@ -229,6 +236,7 @@ var ENV = {
     <p>Alternatively, the notifications can use the <a href="http://getbootstrap.com/components/#glyphicons" target="_blank">Glyphicons</a> icon package. Glyphicons will <b>not</b> added to your application via this addon.</p>
 
     {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
+// config/environment.js
 var ENV = {
   'ember-cli-notifications': {
     icons: 'bootstrap'

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -18,7 +18,9 @@ module.exports = function(environment) {
       // when it is created
     },
     'ember-cli-notifications': {
-      includeFontAwesome: true
+      includeFontAwesome: true,
+      autoClear: true,
+      clearDuration: 2400
     }
   };
 


### PR DESCRIPTION
User configurable properties `autoClear` and `clearDuration` can now be set in consuming app config. 

Fixes #101.
