### PR TITLE
`localClassNameBindings` doesn't add classes on a component's root element.

### DIFF
--- a/addon/components/notification-container.js
+++ b/addon/components/notification-container.js
@@ -8,7 +8,7 @@ export default Component.extend({
   layout,
   styles,
 
-  localClassNameBindings: ['computedPosition'],
+  classNameBindings: ['computedPosition'],
 
   computedPosition: computed('position', function() {
     if (this.get('position')) return this.get(`styles.c-notification__container--${this.get('position')}`);

--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -8,13 +8,10 @@ export default Component.extend({
   layout,
   styles,
 
-  localClassNameBindings: [
+  classNameBindings: [
     'dismissClass',
     'clickableClass',
-    'processedType'
-  ],
-
-  classNameBindings: [
+    'processedType',
     'notification.cssClasses'
   ],
 


### PR DESCRIPTION
This is related with the issue #127 and
fix the issue that `localClassNameBindings` doesn’t bind a class on a component’s root element after upgrading to ember-cli 2.10.0 from 2.9.0.