### PR TITLE
Added 'isDismissed' and jQuery.event arguments to #onClick

### DIFF
--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -63,9 +63,10 @@ export default Component.extend({
     }
   }),
 
-  mouseDown() {
+  mouseDown(event) {
     if (this.get('notification.onClick')) {
-      this.get('notification.onClick')(this.get('notification'));
+      var isDissmised = event.target.className === this.get('closeIcon');
+      this.get('notification.onClick')(this.get('notification'), isDissmised, event);
     }
   },
   mouseEnter() {


### PR DESCRIPTION
Given that ```onClick``` is called regardless of where the user clicks the notification, determining their goal was hard. The ```notification``` object returned by ```onClick``` did not have the value ```dismiss``` on hand, as ```onClick``` ran before the notification was dismissed. Therefore, I was running a timer after ```onClick``` to see whether the user wanted to dismiss or interact. This also limited how many interactions we can add. 

I made this simple PR to return the jQuery event object as well as determine whether the user clicked the dismiss icon or elsewhere.