### PR TITLE
feat: Import Font Awesome assets by default

### DIFF
--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -118,7 +118,7 @@ const NotificationMessagesService = ArrayProxy.extend({
 });
 
 NotificationMessagesService.reopenClass({
-    isServiceFactory: true,
+  isServiceFactory: true
 });
 
 export default NotificationMessagesService;

--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ module.exports = {
   },
 
   included(app) {
+    const projectConfig = this.project.config(app.env);
+    const config = projectConfig['ember-cli-notifications'];
+
     this._super.included.apply(this, arguments);
 
     // see: https://github.com/ember-cli/ember-cli/issues/3718
@@ -38,7 +41,10 @@ module.exports = {
 
     this.app = app;
 
-    this.importFontAwesome(app);
+    // Don't import Font Awesome assets if specified in consuming app
+    if (config.includeFontAwesome !== false) {
+      this.importFontAwesome(app);
+    }
   },
 
   importFontAwesome(app) {
@@ -47,20 +53,15 @@ module.exports = {
     const absoluteFontsPath = path.join(faPath, 'fonts');
     const fontsToImport = fs.readdirSync(absoluteFontsPath);
 
-    const projectConfig = this.project.config(app.env);
-    const config = projectConfig['ember-cli-notifications'] || { includeFontAwesome: false };
-
-    if (config.includeFontAwesome) {
-      fontsToImport.forEach((fontFilename) => {
-        app.import(
-          path.join(fontsPath, fontFilename),
-          { destDir: '/fonts' }
-        );
-      });
-      app.import({
-        development: path.join(cssPath, 'font-awesome.css'),
-        production: path.join(cssPath, 'font-awesome.min.css')
-      });
-    }
+    fontsToImport.forEach((fontFilename) => {
+      app.import(
+        path.join(fontsPath, fontFilename),
+        { destDir: '/fonts' }
+      );
+    });
+    app.import({
+      development: path.join(cssPath, 'font-awesome.css'),
+      production: path.join(cssPath, 'font-awesome.min.css')
+    });
   }
 };

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -230,15 +230,15 @@ var ENV = {
 }
     {{/themed-syntax}}
     <h3>Icons</h3>
-    <p><a href="http://fontawesome.io/" target="_blank">Font Awesome</a> is a requirement to display the icons on the notifications.</p>
+    <p><a href="http://fontawesome.io/" target="_blank">Font Awesome</a> is a requirement to display the icons on the notifications and is installed as a dependency.</p>
 
-    <p>If Font Awesome is not already included in the consuming application, add the following to your environment config file.</p>
+    <p>If you don't want to import the Font Awesome assets into the consuming application, add the following to the app config file.</p>
 
     {{#themed-syntax lang="js" theme="dark" class="h5" withBuffers=false}}
 // config/environment.js
 var ENV = {
   'ember-cli-notifications': {
-    includeFontAwesome: true
+    includeFontAwesome: false
   }
 }
     {{/themed-syntax}}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -23,7 +23,6 @@ module.exports = function(environment) {
     },
 
     'ember-cli-notifications': {
-      includeFontAwesome: true,
       autoClear: false,
       clearDuration: 2400
     }


### PR DESCRIPTION
BREAKING CHANGE: Font Awesome assets are now imported by default, breaking previous convention of import when defined.

To prevent importing the Font Awesome assets for whatever reason:

```js
// config/environment.js
var ENV = {
  'ember-cli-notifications': {
    includeFontAwesome: false
  }
}
```
Fixes #159.