### PR TITLE
Added 'isDismissed' param to notification.onClick

### DIFF
--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -65,11 +65,13 @@ export default Component.extend({
     }
   }),
 
-  mouseDown() {
+  mouseDown(event) {
     if (this.get('notification.onClick')) {
-      this.get('notification.onClick')(this.get('notification'));
+      let isDissmised = event ? event.target.className === this.get('closeIcon') : undefined;
+      this.get('notification.onClick')(this.get('notification'), isDissmised, event);
     }
   },
+  
   mouseEnter() {
     if (this.get('notification.autoClear')) {
       this.set('paused', true);


### PR DESCRIPTION
Updated branch and resubmitting [PR](https://github.com/stonecircle/ember-cli-notifications/pull/135)

Given that onClick is called regardless of where the user clicks the notification, determining their goal was hard. The notification object returned by onClick did not have the value dismiss on hand, as onClick ran before the notification was dismissed. Therefore, I was running a timer after onClick to see whether the user wanted to dismiss or interact. This also limited how many interactions we can add.