### PR TITLE
Add ability to put new notifications at top or bottom of stack (issue #223)

### DIFF
--- a/addon/services/notification-messages-service.js
+++ b/addon/services/notification-messages-service.js
@@ -29,7 +29,9 @@ const NotificationMessagesService = ArrayProxy.extend({
       cssClasses: options.cssClasses
     });
 
-    this.pushObject(notification);
+    const insertAtTop = options.stackNotifications || getWithDefault(globals, 'stackNotifications', false);
+    const arrayOperation = (insertAtTop ? this.unshiftObject : this.pushObject).bind(this);
+    arrayOperation(notification);
 
     if (notification.autoClear) {
       notification.set('remaining', notification.get('clearDuration'));


### PR DESCRIPTION
This introduces functionality to display any new notification messages above or below the currently visible notifications.  This behavior is driven from a `stackNotifications` property on the `options` object.

Fixes https://github.com/mansona/ember-cli-notifications/issues/223