### PR TITLE
feat: Allow icon classes to be configured in ENV #145

### DIFF
--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -1,10 +1,21 @@
 import { htmlSafe } from '@ember/string';
 import { A } from '@ember/array';
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computed, getWithDefault } from '@ember/object';
 import Ember from 'ember';
+import config from 'ember-get-config';
 import layout from '../templates/components/notification-message';
 import styles from '../styles/components/notification-message';
+
+const iconGlobals = (config['ember-cli-notifications'] || {}).iconClasses || {});
+
+const iconDefaults = {
+  close:   'fa fa-times',
+  info:    'fa fa-info-circle',
+  success: 'fa fa-check',
+  warning: 'fa fa-warning',
+  error:   'fa fa-exclamation-triangle'
+};
 
 export default Component.extend({
   layout,
@@ -33,38 +44,14 @@ export default Component.extend({
     return false;
   }),
 
-  closeIcon: computed('icons', function() {
-    if (this.get('icons') === 'bootstrap') return 'glyphicon glyphicon-remove';
-
-    return 'fa fa-times';
+  closeIcon: computed(() => {
+    return getWithDefault(iconGlobals, 'close', iconDefaults.close);
   }),
 
   // Set icon depending on notification type
-  notificationIcon: computed('notification.type', 'icons', function() {
-    const icons = this.get('icons');
-
-    if (icons === 'bootstrap') {
-      switch (this.get('notification.type')){
-        case "info":
-          return 'glyphicon glyphicon-info-sign';
-        case "success":
-          return 'glyphicon glyphicon-ok-sign';
-        case "warning":
-        case "error":
-          return 'glyphicon glyphicon-exclamation-sign';
-      }
-    }
-
-    switch (this.get('notification.type')){
-      case "info":
-        return 'fa fa-info-circle';
-      case "success":
-        return 'fa fa-check';
-      case "warning":
-        return 'fa fa-warning';
-      case "error":
-        return 'fa fa-exclamation-circle';
-    }
+  notificationIcon: computed('notification.type', function() {
+    let type = this.get('notification.type');
+    return getWithDefault(iconGlobals, type, iconDefaults[type]);
   }),
 
   mouseDown() {
@@ -72,6 +59,7 @@ export default Component.extend({
       this.get('notification.onClick')(this.get('notification'));
     }
   },
+
   mouseEnter() {
     if (this.get('notification.autoClear')) {
       this.set('paused', true);

--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -7,7 +7,7 @@ import config from 'ember-get-config';
 import layout from '../templates/components/notification-message';
 import styles from '../styles/components/notification-message';
 
-const iconGlobals = (config['ember-cli-notifications'] || {}).iconClasses || {});
+const iconGlobals = (config['ember-cli-notifications'] || {}).iconClasses || {};
 
 const iconDefaults = {
   close:   'fa fa-times',

--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -51,7 +51,7 @@ export default Component.extend({
   // Set icon depending on notification type
   notificationIcon: computed('notification.type', function() {
     let type = this.get('notification.type');
-    return getWithDefault(iconGlobals, type, iconDefaults[type]);
+    return type && getWithDefault(iconGlobals, type, iconDefaults[type]);
   }),
 
   mouseDown() {


### PR DESCRIPTION
Hey there, we are specifically bitten by #145 when trying to continue to use this addon with semantic-ui. Pretty much we've semi-maintained a fork for quite some time. This is an attempt to join efforts, feel free to edit as needed. :) Open to comments, as I've removed the `bootstrap` specification, seeing that the `iconClasses` hash idea sort of supersedes it.

Thanks!