### PR TITLE
docs: Update Travis badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/stonecircle/ember-cli-notifications.svg)](https://greenkeeper.io/)
 
 [![Download count all time](https://img.shields.io/npm/dt/ember-cli-notifications.svg)](https://www.npmjs.com/package/ember-cli-notifications)
-[![NPM package](https://img.shields.io/npm/v/ember-cli-notifications.svg)](https://www.npmjs.com/package/ember-cli-notifications) [![Build Status](https://img.shields.io/travis/stonecircle/ember-cli-notifications.svg)](https://travis-ci.org/stonecircle/ember-cli-notifications) [![Ember Observer Score](http://emberobserver.com/badges/ember-cli-notifications.svg)](http://emberobserver.com/addons/ember-cli-notifications) [![Code Climate](https://codeclimate.com/github/codeclimate/codeclimate/badges/gpa.svg)](https://codeclimate.com/github/codeclimate/codeclimate)
+[![NPM package](https://img.shields.io/npm/v/ember-cli-notifications.svg)](https://www.npmjs.com/package/ember-cli-notifications)
+[![Build Status](https://travis-ci.org/ynnoj/ember-cli-notifications.svg?branch=master)](https://travis-ci.org/ynnoj/ember-cli-notifications)
+[![Ember Observer Score](http://emberobserver.com/badges/ember-cli-notifications.svg)](http://emberobserver.com/addons/ember-cli-notifications)
+[![Code Climate](https://codeclimate.com/github/codeclimate/codeclimate/badges/gpa.svg)](https://codeclimate.com/github/codeclimate/codeclimate)
 
 An [Ember CLI] addon that adds [Atom] inspired notification messages to your app.
 


### PR DESCRIPTION
This PR updates the URL to the Travis build. The change is: changed username.

Also: added non-visible whitespace.