### PR TITLE
Accessibility improvements

### DIFF
--- a/addon/components/notification-container.js
+++ b/addon/components/notification-container.js
@@ -11,9 +11,11 @@ export default Component.extend({
   notifications: service(),
 
   classNameBindings: ['computedPosition', ':ember-cli-notifications-notification__container'],
-  attributeBindings: ['computedStyle:style', 'position:data-test-notification-container'],
+  attributeBindings: ['computedStyle:style', 'position:data-test-notification-container', 'ariaLive:aria-live', 'role'],
 
   zindex: '1060',
+  role: 'status',
+  ariaLive: 'polite',
 
   computedPosition: computed('position', function() {
     return `ember-cli-notifications-notification__container--${this.get('position')}`;

--- a/addon/styles/components/notification-message.css
+++ b/addon/styles/components/notification-message.css
@@ -54,6 +54,8 @@
 .ember-cli-notifications-notification__container .c-notification__close {
   margin-left: var(--ecn-spacing-2);
   align-self: flex-start;
+  background-color: rgba(0,0,0,0);
+  border-width: 0;
   opacity: .74;
   cursor: pointer;
 }

--- a/addon/templates/components/notification-message.hbs
+++ b/addon/templates/components/notification-message.hbs
@@ -14,9 +14,9 @@
     {{else}}
       {{notification.message}}
     {{/if}}
-    <div class="c-notification__close" {{action "removeNotification" bubbles=false}} title="Dismiss this notification">
+    <button class="c-notification__close" {{action "removeNotification" bubbles=false}} aria-label="Dismiss this notification">
       <svg class="c-notification__svg" name="close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26" width="1024" height="1024" fill="#FFF"><path d="M21.734 19.64l-2.097 2.094a.983.983 0 0 1-1.395 0L13 16.496l-5.238 5.238a.988.988 0 0 1-1.399 0l-2.097-2.093a.988.988 0 0 1 0-1.399L9.504 13 4.266 7.762a.995.995 0 0 1 0-1.399l2.097-2.097a.988.988 0 0 1 1.399 0L13 9.508l5.242-5.242a.983.983 0 0 1 1.395 0l2.097 2.093a.996.996 0 0 1 .004 1.403L16.496 13l5.238 5.242a.988.988 0 0 1 0 1.399z"/></svg>
-    </div>
+    </button>
   </div>
 
   {{#if notification.autoClear}}


### PR DESCRIPTION
Two changes for making the notifications more accessible.

1. Add aria elements to the container so screen readers alert users to new notifications.
2. Make the close element a button so keyboard users can close it.