### PR TITLE
Remove extra semi-colon from notification-max-height usage

### DIFF
--- a/addon/styles/components/notification-message.css
+++ b/addon/styles/components/notification-message.css
@@ -7,7 +7,7 @@
   border-radius: var(--notification-border-radius);
   border-bottom: 1rem;
   color: white;
-  max-height: var(--notification-max-height;);
+  max-height: var(--notification-max-height);
   animation: notification-hide 250ms cubic-bezier(.33859, -.42, 1, -.22), notification-shrink 250ms 250ms cubic-bezier(.5, 0, 0, 1);
   animation-fill-mode: forwards;
   margin-bottom: var(--spacing-2);
@@ -106,7 +106,7 @@
 @keyframes notification-shrink {
   0% {
     opacity: 0;
-    max-height: var(--notification-max-height;);
+    max-height: var(--notification-max-height);
     transform: scale(.8);
   }
 


### PR DESCRIPTION
There is an extra semi-colon in the usage of `var(--notification-max-height;);`

When running with `ember s --environment=production` the resulting vendor.css would be incorrect. 
Notice the missing closing paren after --notification-max-height

```
.ember-cli-notifications-notification__container .c-notification {
    display: flex;
    align-items: stretch;
    position: relative;
    overflow: hidden;
    border-radius: var(--notification-border-radius);
    border-bottom: 1rem;
    color: #fff;
    max-height: var(--notification-max-height;
    animation:notification-hide 250ms cubic-bezier(.33859,-.42,1,-.22),notification-shrink 250ms 250ms cubic-bezier(.5,0,0,1);animation-fill-mode:forwards;margin-bottom:var(--spacing-2)
}


@keyframes notification-shrink {
    0% {
        opacity: 0;
        max-height: var(--notification-max-height;
        transform:scale(.8)}

    100% {
        opacity: 0;
        max-height: 0;
        transform: scale(.8)
    }
}
```
This resulted in almost none of the css being applied in the browser.
