### PR TITLE
Fix mouseEnter/Leave deprecations

### DIFF
--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -9,18 +9,8 @@ import layout from '../templates/components/notification-message';
 
 export default Component.extend({
   layout,
-
+  tagName: '',
   notifications: service(),
-
-  classNameBindings: [
-    'dismissClass',
-    'clickableClass',
-    'processedType',
-    'notification.cssClasses',
-    ':c-notification'
-  ],
-
-  attributeBindings: ['notification.type:data-test-notification-message'],
 
   paused: false,
 
@@ -50,19 +40,6 @@ export default Component.extend({
     return '';
   }),
 
-  mouseEnter() {
-    if (this.get('notification.autoClear')) {
-      this.set('paused', true);
-      this.notifications.pauseAutoClear(this.get('notification'));
-    }
-  },
-
-  mouseLeave() {
-    if (this.get('notification.autoClear')) {
-      this.set('paused', false);
-      this.notifications.setupAutoClear(this.get('notification'));
-    }
-  },
 
   processedType: computed('notification.type', function() {
     if (this.get('notification.type') && ['info', 'success', 'warning', 'error'].indexOf(this.get('notification.type')) !== -1 ) {
@@ -88,6 +65,20 @@ export default Component.extend({
 
     removeNotification() {
       this.get('notifications').removeNotification(this.get('notification'));
-    }
+    },
+
+    handleMouseEnter() {
+      if (this.get('notification.autoClear')) {
+        this.set('paused', true);
+        this.notifications.pauseAutoClear(this.get('notification'));
+      }
+    },
+
+    handleMouseLeave() {
+      if (this.get('notification.autoClear')) {
+        this.set('paused', false);
+        this.notifications.setupAutoClear(this.get('notification'));
+      }
+    },
   }
 });

--- a/addon/templates/components/notification-message.hbs
+++ b/addon/templates/components/notification-message.hbs
@@ -1,21 +1,25 @@
-<div class="c-notification__icon">
-  {{#if notificationSVGPath}}
-    <svg class="c-notification__svg" fill="#FFFFFF" viewBox="0 0 24 24" height="48" width="48" xmlns="http://www.w3.org/2000/svg">
-      <path d={{notificationSVGPath}}></path>
-    </svg>
-  {{/if}}
-</div>
-<div class="c-notification__content" {{action "handleOnClick"}}>
-  {{#if notification.htmlContent}}
-    {{{notification.message}}}
-  {{else}}
-    {{notification.message}}
-  {{/if}}
-  <div class="c-notification__close" {{action "removeNotification" bubbles=false}} title="Dismiss this notification">
-    <svg class="c-notification__svg" name="close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26" width="1024" height="1024" fill="#FFF"><path d="M21.734 19.64l-2.097 2.094a.983.983 0 0 1-1.395 0L13 16.496l-5.238 5.238a.988.988 0 0 1-1.399 0l-2.097-2.093a.988.988 0 0 1 0-1.399L9.504 13 4.266 7.762a.995.995 0 0 1 0-1.399l2.097-2.097a.988.988 0 0 1 1.399 0L13 9.508l5.242-5.242a.983.983 0 0 1 1.395 0l2.097 2.093a.996.996 0 0 1 .004 1.403L16.496 13l5.238 5.242a.988.988 0 0 1 0 1.399z"/></svg>
+<div class="c-notification {{this.dismissClass}} {{this.clickableClass}} {{this.processedType}} {{this.notification.cssClasses}}"
+  {{on "mouseenter" (action "handleMouseEnter")}}
+  {{on "mouseleave" (action "handleMouseLeave")}} data-test-notification-message={{notification.type}}>
+  <div class="c-notification__icon">
+    {{#if notificationSVGPath}}
+      <svg class="c-notification__svg" fill="#FFFFFF" viewBox="0 0 24 24" height="48" width="48" xmlns="http://www.w3.org/2000/svg">
+        <path d={{notificationSVGPath}}></path>
+      </svg>
+    {{/if}}
   </div>
-</div>
+  <div class="c-notification__content" {{action "handleOnClick"}}>
+    {{#if notification.htmlContent}}
+      {{{notification.message}}}
+    {{else}}
+      {{notification.message}}
+    {{/if}}
+    <div class="c-notification__close" {{action "removeNotification" bubbles=false}} title="Dismiss this notification">
+      <svg class="c-notification__svg" name="close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26" width="1024" height="1024" fill="#FFF"><path d="M21.734 19.64l-2.097 2.094a.983.983 0 0 1-1.395 0L13 16.496l-5.238 5.238a.988.988 0 0 1-1.399 0l-2.097-2.093a.988.988 0 0 1 0-1.399L9.504 13 4.266 7.762a.995.995 0 0 1 0-1.399l2.097-2.097a.988.988 0 0 1 1.399 0L13 9.508l5.242-5.242a.983.983 0 0 1 1.395 0l2.097 2.093a.996.996 0 0 1 .004 1.403L16.496 13l5.238 5.242a.988.988 0 0 1 0 1.399z"/></svg>
+    </div>
+  </div>
 
-{{#if notification.autoClear}}
-  <div class="c-notification__countdown" style={{notificationClearDuration}}></div>
-{{/if}}
+  {{#if notification.autoClear}}
+    <div class="c-notification__countdown" style={{notificationClearDuration}}></div>
+  {{/if}}
+</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8214,6 +8214,41 @@
         }
       }
     },
+    "ember-modifier-manager-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
+      }
+    },
+    "ember-on-modifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-on-modifier/-/ember-on-modifier-1.0.0.tgz",
+      "integrity": "sha512-OPX5QrNiyXXQ//uN4cFj7gz5pt0rBK5c6LPEMP5iSK2I1J+WtiHM5Kg7mVCM7VziMiRUBVe3wp8CAE26m45hsA==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "^2.0.2",
+        "ember-cli-babel": "^7.8.0",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-modifier-manager-polyfill": "^1.0.3"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
+          }
+        }
+      }
+    },
     "ember-prism": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ember-prism/-/ember-prism-0.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-on-modifier": "^1.0.0",
     "ember-prism": "^0.5.0",
     "ember-qunit": "^4.6.0",
     "ember-radio-buttons": "^5.0.0",


### PR DESCRIPTION
Fix: https://github.com/mansona/ember-cli-notifications/issues/247 

Make some changes to accommodate the new {{on}} helper in the message component. 
Remove component tag, class name bindings and attr bindings and add a wrapper div tag with all the class names, data test attr, mouse enter/leave events.

