### PR TITLE
Add configuration option to exclude all CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,24 +2,32 @@
 
 const CssImport = require('postcss-import');
 const PresetEnv = require('postcss-preset-env');
-const broccoliPostCSS = require('broccoli-postcss')
+const broccoliPostCSS = require('broccoli-postcss');
 const mergeTrees = require('broccoli-merge-trees');
 const funnel = require('broccoli-funnel');
 const get = require('lodash.get');
 const { join } = require('path');
+const pkg = require('./package.json');
 
 module.exports = {
   name: require('./package').name,
 
   treeForAddon() {
-    var tree = this._super(...arguments);
+    let tree = this._super(...arguments);
+    let app = this._findHost();
+    let options = typeof app.options === 'object' ? app.options : {};
+    let addonConfig = options[pkg.name] || {};
 
     const addonWithoutStyles = funnel(tree, {
       exclude: ['**/*.css'],
     });
 
+    if (addonConfig.excludeCSS === true) {
+      return addonWithoutStyles;
+    }
+
     const addonStyles = funnel(tree, {
-      include: ['**/*.css']
+      include: ['**/*.css'],
     });
 
     // I don't know exactly why targets is private so I am using `get()` to make
@@ -35,8 +43,9 @@ module.exports = {
           stage: 3,
           features: { 'nesting-rules': true },
           overrideBrowserslist,
-        })
-      ]});
+        }),
+      ],
+    });
 
     return mergeTrees([addonWithoutStyles, processedStyles]);
   },


### PR DESCRIPTION
This can be used together with PostCSS or other processors which support importing from `node_modules` to consume the unmangled CSS, which can be useful in modern environments.