### PR TITLE
services/notifications: Use new `content` array for each service instance

### DIFF
--- a/addon/services/notifications.js
+++ b/addon/services/notifications.js
@@ -14,7 +14,7 @@ export default Service.extend({
   init() {
     this._super(...arguments);
     this.set('content', A());
-  }
+  },
 
   // Method for adding a notification
   addNotification(options) {

--- a/addon/services/notifications.js
+++ b/addon/services/notifications.js
@@ -11,7 +11,10 @@ const notificationAssign = assign || merge;
 const globals = config['ember-cli-notifications'] || {}; // Import app config object
 
 export default Service.extend({
-  content: A(),
+  init() {
+    this._super(...arguments);
+    this.set('content', A());
+  }
 
   // Method for adding a notification
   addNotification(options) {


### PR DESCRIPTION


Resolves #277

/cc @mansona 