### PR TITLE
fix: don't use deprecated getWithDefault (fix #286)

### DIFF
--- a/addon/services/notifications.js
+++ b/addon/services/notifications.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { assign, merge } from '@ember/polyfills';
 import { A } from '@ember/array';
 import { isEmpty } from '@ember/utils';
-import EmberObject, { getWithDefault, set } from '@ember/object';
+import EmberObject, { set } from '@ember/object';
 import { run } from '@ember/runloop';
 import config from 'ember-get-config';
 
@@ -23,11 +23,12 @@ export default Service.extend({
       throw new Error("No notification message set");
     }
 
+    const defaultAutoClear = typeof globals.autoClear === 'boolean' ? globals.autoClear : false;
     const notification = EmberObject.create({
       message: options.message,
       type: options.type || 'info',
-      autoClear: (isEmpty(options.autoClear) ? getWithDefault(globals, 'autoClear', false) : options.autoClear),
-      clearDuration: options.clearDuration || getWithDefault(globals, 'clearDuration', 3200),
+      autoClear: (isEmpty(options.autoClear) ? defaultAutoClear : options.autoClear),
+      clearDuration: options.clearDuration || globals.clearDuration || 3200,
       onClick: options.onClick,
       htmlContent: options.htmlContent || false,
       cssClasses: options.cssClasses


### PR DESCRIPTION
Alternatively, the [`??` (nullish coalescing) operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) could be used instead, but this seemed a reasonable solution.

Fixes #286 