### PR TITLE
Import `htmlSafe` from '@ember/template' rather than '@ember/string'

### DIFF
--- a/addon/components/notification-container.js
+++ b/addon/components/notification-container.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { inject as service } from '@ember/service';
 
 import layout from '../templates/components/notification-container';

--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import Ember from 'ember';
 
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 


### PR DESCRIPTION
Deprecation id: [ember-string.htmlsafe-ishtmlsafe](https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe)

Not sure of version compatibility but thought I'd open the PR to start a discussion.