### PR TITLE
Drop support for Node.js 8 and 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 8.x
+          node-version: 12.x
 
       - run: npm ci
       - run: npm run lint:hbs
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
         with:
-          node-version: 8.x
+          node-version: 12.x
 
       - run: npm ci
       - run: npm test
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
         with:
-          node-version: 8.x
+          node-version: 12.x
 
       - run: npm install --no-package-lock
       - run: npm test
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
         with:
-          node-version: 8.x
+          node-version: 12.x
 
       - run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "qunit-dom": "^0.9.2"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "12.* || >= 14.*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Node 10 goes EOL by the end of April and Node 8 has already reached EOL, so we could probably drop support for these by now. (see https://nodejs.org/en/about/releases/)