### PR TITLE
Relax `ember-get-config` requirement to allow v0.3.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "broccoli-postcss": "^5.0.0",
         "ember-cli-babel": "^7.26.3",
         "ember-cli-htmlbars": "^5.7.1",
-        "ember-get-config": "^0.2.4",
+        "ember-get-config": "^0.2.4 || ^0.3.0",
         "ember-on-modifier": "^1.0.0",
         "lodash.get": "^4.4.2",
         "postcss-import": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "broccoli-postcss": "^5.0.0",
     "ember-cli-babel": "^7.26.3",
     "ember-cli-htmlbars": "^5.7.1",
-    "ember-get-config": "^0.2.4",
+    "ember-get-config": "^0.2.4 || ^0.3.0",
     "ember-on-modifier": "^1.0.0",
     "lodash.get": "^4.4.2",
     "postcss-import": "^12.0.1",


### PR DESCRIPTION
v0.2.x is still using ember-cli-babel v6.x, which is causing deprecation warnings with current versions of Ember.js