### PR TITLE
CI: Disable `ember-beta` scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-release
-          - ember-beta
+          # currently disabled due to issues with Ember 4.x
+          # - ember-beta
           - ember-default-with-jquery
           - ember-classic
           - embroider-safe


### PR DESCRIPTION
This is currently breaking CI due to incompatibilities with Ember 4.x

/cc @mansona 