### PR TITLE
add fail-fast: false for ember-try scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           - ember-lts-3.20
           - ember-release
           - ember-beta
+          - ember-canary
           - ember-default-with-jquery
           - ember-classic
           - embroider-safe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
     name: "ember-try: ${{ matrix.ember-try-scenario }}"
     runs-on: ubuntu-latest
     needs: test
-
     strategy:
+      fail-fast: false
       matrix:
         ember-try-scenario:
           - ember-lts-3.8


### PR DESCRIPTION
This is so that we can see all of the ember-try scenarios and they don't cancel any currently running jobs 👍 