### PR TITLE
fix: don't consume clicks when no onClick given (fix #274)

### DIFF
--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -71,8 +71,13 @@ export default class NotificationMessage extends Component {
 
   @action
   handleOnClick(event) {
-    event.preventDefault();
-    this.notification.onClick?.(this.notification);
+    // If a handler was provided then use it instead of the default handler,
+    // otherwise take no action to avoid breaking native functionality in
+    // things like <a href="...">link</a> and <details><summary>twisty</summary>lorem ipsum</details
+    if (typeof this.notification.onClick === 'function') {
+      event.preventDefault();
+      this.notification.onClick(this.notification);
+    }
   }
 
   @action


### PR DESCRIPTION
To avoid the problems described in #269 and #274 (that #270 was supposed to fix) this PR proposes making the `handleOnClick` function inert when `@onClick` is not provided.

Demo: https://github.com/jacobq/ecm-clickProblem