### PR TITLE
Refactor: Handle notification htmlContent in backing class

### DIFF
--- a/addon/components/notification-message.js
+++ b/addon/components/notification-message.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/no-classic-components, ember/no-computed-properties-in-native-classes */
 import Component from '@ember/component';
-import { htmlSafe } from '@ember/template';
+import { htmlSafe, isHTMLSafe } from '@ember/template';
 import { action, computed, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 
@@ -14,6 +14,17 @@ export default class NotificationMessage extends Component {
   @service notifications;
 
   paused = false;
+
+  @computed('notification.{htmlContent,message}')
+  get message() {
+    const { htmlContent, message } = this.notification;
+
+    if (isHTMLSafe(message) || !htmlContent) {
+      return message;
+    }
+
+    return htmlSafe(message);
+  }
 
   @computed('notification.dismiss')
   get dismissClass() {

--- a/addon/templates/components/notification-message.hbs
+++ b/addon/templates/components/notification-message.hbs
@@ -23,11 +23,7 @@
     {{/if}}
   </div>
   <div class="c-notification__content" {{on "click" this.handleOnClick}}>
-    {{#if @notification.htmlContent}}
-      {{{@notification.message}}}
-    {{else}}
-      {{@notification.message}}
-    {{/if}}
+    {{this.message}}
     <div
       class="c-notification__close"
       {{on "click" this.removeNotification}}


### PR DESCRIPTION
This change is made with the intention of deprecating and later removing the `htmlContent` flag from the message, shifting the responsibility of creating htmlSafe content to the consuming application in the future.