### PR TITLE
Update minimum supported Node.js version to v16 (No longer relevant)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   FORCE_COLOR: 1
+  NODE_VERSION: 16.x
 
 jobs:
   lint:
@@ -17,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
-      - run: npm i -g npm@7
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
       - run: npm ci
       - run: npm run lint:hbs
       - run: npm run lint:js
@@ -31,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: mansona/npm-lockfile-version@v1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
-      - run: npm i -g npm@7
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
       - run: npm ci
       - run: npm run test:ember
 
@@ -45,11 +46,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
-      - run: npm i -g npm@7
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
       - run: npm install --no-package-lock
       - run: npm run test:ember
 
@@ -76,11 +77,11 @@ jobs:
           - ember-release-no-deprecations
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
-      - run: npm i -g npm@7
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
       - run: npm ci
 
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: npm i -g npm@7
       - run: npm ci
       - run: npm run lint:hbs
@@ -35,7 +35,7 @@ jobs:
       - uses: mansona/npm-lockfile-version@v1
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: npm i -g npm@7
       - run: npm ci
       - run: npm run test:ember
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: npm i -g npm@7
       - run: npm install --no-package-lock
       - run: npm run test:ember
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: npm i -g npm@7
       - run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "webpack": "^5.62.0"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "webpack": "^5.62.0"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Node.js v12 is no longer officially supported, so it is time to update to at least v14. (see https://github.com/nodejs/release#release-schedule)