### PR TITLE
add --singlePackage to release-plan config

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: 
+    types:
       - labeled
 
 concurrency:
@@ -28,19 +28,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      
+
       - uses: pnpm/action-setup@v2
         with:
           version: 8
       - run: pnpm install --frozen-lockfile
-      
+
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |
           set -x
-          
-          pnpm release-plan prepare
-          
+
+          pnpm release-plan prepare --singlePackage=ember-cli-notificaitons
+
           echo 'text<<EOF' >> $GITHUB_OUTPUT
           jq .description .release-plan.json -r >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT


### PR DESCRIPTION
I kinda expected that this work just work without needing `--singlePackage` but sure 🤷 This is something to figure out for https://github.com/embroider-build/release-plan/issues/19